### PR TITLE
Update to Docker and Webhook Workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,17 +1,32 @@
 name: Docker Image CI
 
 on:
-  push:
+  merge_group:
+    types: [checks_requested]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
     branches:
       - eol-release/koa
-    paths:
-      - 'Dockerfile'
-      - 'requirements/**'
-      - 'themes/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
+  variables:
+    uses: eol-uchile/edx-platform/.github/workflows/variables.yml@eol/koa.master
   build:
+    needs: [ variables ]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      TS: ${{ needs.variables.outputs.timestamp }}
+      RELEASE-NAME: ${{ needs.variables.outputs.release-name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -20,21 +35,29 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Build OpenedX
-        run: docker build . --file ./Dockerfile --tag ghcr.io/eol-uchile/eol-edx:${GITHUB_SHA} --tag ghcr.io/eol-uchile/eol-edx:latest --target base
+        run: docker build . --file ./Dockerfile --tag ghcr.io/eol-uchile/eol-edx:${{ env.RELEASE-NAME }} --tag ghcr.io/eol-uchile/eol-edx:${{ env.RELEASE-NAME }}-${{ env.TS }} --target base
 
       - name: Build Static files for OpenedX S3
-        run: docker build . --file ./Dockerfile --tag ghcr.io/eol-uchile/eol-edx:s3-static-${GITHUB_SHA} --tag ghcr.io/eol-uchile/eol-edx:s3-static-koa --target s3
+        run: docker build . --file ./Dockerfile --tag ghcr.io/eol-uchile/eol-edx:s3-static-${{ env.RELEASE-NAME }} --tag ghcr.io/eol-uchile/eol-edx:s3-static-${{ env.RELEASE-NAME }}-${{ env.TS }} --target s3
 
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'merge_group' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: eolito
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push
+        if: ${{ github.event_name == 'merge_group' }}
         run: |
-          docker push ghcr.io/eol-uchile/eol-edx:${GITHUB_SHA}
-          docker push ghcr.io/eol-uchile/eol-edx:latest
-          docker push ghcr.io/eol-uchile/eol-edx:s3-static-${GITHUB_SHA}
-          docker push ghcr.io/eol-uchile/eol-edx:s3-static-koa
+          docker push ghcr.io/eol-uchile/eol-edx:${{ env.RELEASE-NAME }}
+          docker push ghcr.io/eol-uchile/eol-edx:${{ env.RELEASE-NAME }}-${{ env.TS }}
+          docker push ghcr.io/eol-uchile/eol-edx:s3-static-${{ env.RELEASE-NAME }}
+          docker push ghcr.io/eol-uchile/eol-edx:s3-static-${{ env.RELEASE-NAME }}-${{ env.TS }}
+
+  webhook:
+      needs: [ variables, build ]
+      if: ${{ github.event_name == 'merge_group' }}
+      uses: ./.github/workflows/webhook.yml
+      secrets: inherit

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -1,18 +1,18 @@
-name: Webhook Update staging
+name: Webhook Update EOL
 
 on:
-  workflow_run:
-    workflows: ["Docker Image CI"]
-    types:
-      - completed
+  workflow_call:
+    secrets:
+      WEBHOOK_SECRET:
+        required: true
   repository_dispatch:
     types: [debug-webhook]
 
 jobs:
-  build:
+  webhook:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion }} == "success" || ${{ github.event.client_payload.debug }} == "eol"
+    if: ${{ github.event_name }} == 'workflow_call' || ${{ github.event.client_payload.debug }}
     steps:
-      - name: Trigger second repository
+      - name: Trigger edx-kustomize repository workflow
         run: |
-          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "eol"}}'
+          curl --fail-with-body --silent -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "eol"}}'


### PR DESCRIPTION
**docker.yml**

- The workflow trigger has been updated to include the 'merge_group' action with the 'checks_requested' type, and the 'pull_request' action with the 'opened', 'reopened', and 'synchronize' types, restricted to the 'eol-release/koa' branch.
- Concurrency configuration has been added to manage jobs in specific groups, with the option to cancel jobs in progress if another is started in the same group.
- New environment variables have been introduced, and the logic for building Docker images has been modified to use these variables in the tag names and build targets.
- A condition has been added for the initiation of the login action to the GitHub Container Registry and the push action only on the 'merge_group' event.
- A webhook action has been added to execute after the preceding jobs are completed, only on the 'merge_group' event, which utilizes an external configuration file and inherits the necessary secrets.

**webhook.yml**
- The name of the step has been modified to better reflect its function.