### PR TITLE
build: use original edx-proctoring release 2.6.7

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/edx-proctoring@a928e8a15aaad5bfa7a2fa34005a95b6e36eb713#egg=edx-proctoring
+-e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring
 -e git+https://github.com/eol-uchile/edx-ucursos@2.0.0#egg=edxucursos
 -e git+https://github.com/eol-uchile/eol_contact_form@c59e764eee1c8bcae8fb25011a78b2353d14aa63#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock


### PR DESCRIPTION
Updates the edx-proctoring repository to use the official repository and a stable release in our environment