### PR TITLE
build: add eol-api in 1.2.0 tag

### DIFF
--- a/requirements/apis.txt
+++ b/requirements/apis.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/eol-uchile/CMM-API@03c52a7087341288f01aa3fe130c6d3f0e34cade#egg=cmmapi
+-e git+https://github.com/eol-uchile/eol-api@1.2.0#egg=eol_api


### PR DESCRIPTION
Se agrega eol-api  que agrega un modelo nuevo llamado ClientCourseAccess el que permite el enlace entre los client y los cursos a lo que les queremos dar acceso. Se agregan dos APIs :
StudentGrades : permite traer datos de un cursos basado en un id ya las notas de sus estudiantes

ClientCourses: permite traer una lista de cursos a los que tiene acceso un cliente en particular