### PR TITLE
build: update eol-container-xblock to tag 1.1.0

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -5,7 +5,7 @@
 -e git+https://github.com/eol-uchile/edx-sga@0.10.0+eol3.1.2#egg=edx-sga
 -e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/eol-conditional-xblock@1.0.0#egg=eolconditional-xblock
--e git+https://github.com/eol-uchile/eol-container-xblock@v1.0.0#egg=eolcontainer-xblock
+-e git+https://github.com/eol-uchile/eol-container-xblock@v1.1.0#egg=eolcontainer-xblock
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@df549273a21c6b4674c6645940d7f33c4c8a2aea#egg=eolcourseprogram-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0#egg=eoldialogs-xblock


### PR DESCRIPTION
Se actualiza el tag de eol-container-xblock  a 1.1.0 donde se modificar cosas de CI
Tambien se modifico la forma en la que se monta el xblock pasando de campos de textos a select predefinidos. Fue revisar por Diego en staging