### PR TITLE
chore: update assets scripts

### DIFF
--- a/cms-assets.py
+++ b/cms-assets.py
@@ -10,9 +10,7 @@ COMPREHENSIVE_THEME_LOCALE_PATHS = [
 	"/openedx/themes/alpha-project-theme/conf/locale",
 	"/openedx/themes/cmm-openedx/conf/locale",
 	"/openedx/themes/eduonline-ing/conf/locale",
-	"/openedx/themes/eol-uchile/conf/locale",
 	"/openedx/themes/eol-uchile-2020/conf/locale",
-	"/openedx/themes/redfid-theme/conf/locale",
 	"/openedx/themes/virtual-labx-theme/conf/locale"
 ]
 STATIC_ROOT_BASE = '/openedx/staticfiles'

--- a/lms-assets.py
+++ b/lms-assets.py
@@ -10,9 +10,7 @@ COMPREHENSIVE_THEME_LOCALE_PATHS = [
 	"/openedx/themes/alpha-project-theme/conf/locale",
 	"/openedx/themes/cmm-openedx/conf/locale",
 	"/openedx/themes/eduonline-ing/conf/locale",
-	"/openedx/themes/eol-uchile/conf/locale",
 	"/openedx/themes/eol-uchile-2020/conf/locale",
-	"/openedx/themes/redfid-theme/conf/locale",
 	"/openedx/themes/virtual-labx-theme/conf/locale"
 ]
 STATIC_ROOT_BASE = '/openedx/staticfiles'


### PR DESCRIPTION
Update asset setting scripts to remove already removed themes.

Complements fda6e1f3bf45126c01db6d49098577385853edf8 & 6be68e6b1b3600a19c60c16c7712c8c66d88770c.