### PR TITLE
build: update img_annotation tag to 1.0.1

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -11,7 +11,7 @@
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0#egg=eoldialogs-xblock
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.3#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
--e git+https://github.com/eol-uchile/eol_img_annotation@1.0.0#egg=img-annotation
+-e git+https://github.com/eol-uchile/eol_img_annotation@1.0.1#egg=img-annotation
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/eol-persistent-tab-xblock@1.0.0#egg=eolpersistenttab-xblock
 -e git+https://github.com/eol-uchile/eol-question-xblock@v1.0.0#egg=eolquestion-xblock


### PR DESCRIPTION
- Se eliminan funciones que no se estan usando
- Se agregan test para aumentar el coverage
- Se agrega el setup.cfg
- Se elimina test.sh
- se actualiza la versión semantica

[compare entre versiones 1.0.0 vs 1.0.1 ](https://github.com/eol-uchile/eol_img_annotation/compare/1.0.0..1.0.1)