### PR TITLE
build: update tags to apps, xblock, etc with changes

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring
--e git+https://github.com/eol-uchile/course_classification@1.6.0#egg=course_classification
+-e git+https://github.com/eol-uchile/course_classification@1.6.1+l#egg=course_classification
 -e git+https://github.com/eol-uchile/edx-ucursos@3.1.0+l#egg=edxucursos
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0+l#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3+l#egg=eol_contact_form
@@ -7,4 +7,4 @@
 -e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_survey@3.2.1+l#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.1+l#egg=eol_vimeo
--e git+https://github.com/eol-uchile/uchileedxlogin@2.0.1#egg=uchileedxlogin
+-e git+https://github.com/eol-uchile/uchileedxlogin@2.0.2+l#egg=uchileedxlogin

--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -2,11 +2,11 @@
 -e git+https://github.com/cmmedu/cmmedu-ordertable-xblock@v1.0.1#egg=cmmedu-ordertable-xblock
 -e git+https://github.com/eol-uchile/edx-ora2@e873498bd2671b830f19a2441ec1608b7d4bbbc4#egg=ora2
 -e git+https://github.com/eol-uchile/edx-sga@0.10.0+eol3.1.2#egg=edx-sga
--e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
+-e git+https://github.com/eol-uchile/edx_xblock_scorm@0.5.1+l#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/eol-conditional-xblock@1.0.0+l#egg=eolconditional-xblock
--e git+https://github.com/eol-uchile/eol-container-xblock@v1.1.0#egg=eolcontainer-xblock
+-e git+https://github.com/eol-uchile/eol-container-xblock@v1.2.0+l#egg=eolcontainer-xblock
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@0.2.0+l#egg=eolcourseprogram-xblock
--e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
+-e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.1.0+l#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0+l#egg=eoldialogs-xblock
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4+l#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0+l#egg=eolgradediscussion


### PR DESCRIPTION
- Se actualiza el tag de course_classification desde 1.6.0 a 1.6.1+l
   - Se agrega un fix para lilac
- Se actualiza el tag de eol-container-xblock desde 1.1.0 a 1.2.0+l
    - Se actualiza la vista de studio, la view y el .js agregaron el borrar en cascada las opcionees seleccionadas
- Se actualiza el tag de eol-dialogs-question-xblock desde 1.0.0 a 1.1.0+l
   - Se agrega last_submission_time
- Se actualiza el tag de uchileedxlogin desde 2.0.1 a 2.0.2+l
   - Se elimina ignore_email_blacklist
- Se agrega edx_xblock_scorm desde el commit c23184c0e22a7847f0b0c917bbe431c2973770fb a el tag 0.5.1+l
  - Se actualizan importaciones para lilac y se borra una sin usar

