### PR TITLE
build: update eol_completion tag to 2.1.1+l

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/eol_completion@2.1.0+l#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.1+l#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@0.0.1+l#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_feedback@0.0.3+l#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1+l#egg=eol_progress_tab


### PR DESCRIPTION
This new version of eol_completion fixes a bug introduced in https://github.com/eol-uchile/eol_completion/pull/27 where the signal handlers ran for every task, so unrelated tasks emitted logs as if they came from this app. The logs are removed until future implementation after https://github.com/eol-uchile/eol_completion/issues/31.