### PR TITLE
build: rm eol_jump xblock and from eol-theme

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -4,7 +4,6 @@
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0+l#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3+l#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0+l#egg=eol_duplicate_xblock
--e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_survey@3.2.1+l#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.1+l#egg=eol_vimeo
 -e git+https://github.com/eol-uchile/uchileedxlogin@2.0.2+l#egg=uchileedxlogin


### PR DESCRIPTION
Se elimina eol-jump del xblock
Se actualiza el tema desde la verion 3.0.0 a la version 3.1.1, con los siguientes cambios:
  -   Se agregan las herramientas para traducir dejando los archivos separados por tipo de archivo
  -   Se separan los archivos .po
  -   Se eliminan templates de email pues están en platform
  -   Se actualizan los msgid de español a ingles manteniendo las traducciones
  -   Se elimina eol_jump_to